### PR TITLE
fix: Remove PHP 8.3 from GitHub Actions test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.3, 8.4, 8.5]
+                php: [8.4, 8.5]
                 stability: [prefer-lowest, prefer-stable]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.stability }}


### PR DESCRIPTION
Hi Nuno,

I know you decided to support php 8.3 on stream but Pest 5 does not support it.

The simplest fix is to remove php 8.3 for now. Otherwise we need to pin pest to v4. Leaving the decision to you!

