### PR TITLE
Add source diff and clickable links to audit command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,8 @@ A GitHub zipball answers 403 to a request that carries no `User-Agent` header, a
 
 The metadata of a package is at `https://repo.packagist.org/p2/<vendor>/<name>.json`. The array `packages.<name>` holds the newest version first, and each entry holds `version` and `dist.url`. `App\Registry\Packagist` reads this endpoint.
 
+`Symfony\Component\Console\Formatter\OutputFormatter` renders the `href` style as a terminal hyperlink, and `App\Support\SourceDiffUrl` builds compare URLs for HTTPS GitHub and GitLab source URLs without a network call.
+
 Read the full tree, and add no cache for speed. A hash of 6,953 files and 91.2 MB in `vendor/` takes 0.85 s.
 
 ---

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ When the ledger already covers the installed version, the report stays local and
 pet audit carbonphp/carbon-doctrine-types --from=3.1.0
 ```
 
+When the trusted and installed versions differ, the report gives you a clickable `view diff` link when the package metadata names a GitHub or GitLab source repository.
+
 <a name="reviewing-the-source-of-a-change"></a>
 ### Reviewing the Source of a Change
 

--- a/app/Commands/AuditCommand.php
+++ b/app/Commands/AuditCommand.php
@@ -22,9 +22,6 @@ use LaravelZero\Framework\Commands\Command;
 
 final class AuditCommand extends Command
 {
-    /**
-     * @var string
-     */
     protected $signature = 'audit
         {package? : Audit one installed package, as vendor/name}
         {--from= : Show the delta from this version rather than the trusted one}
@@ -34,9 +31,6 @@ final class AuditCommand extends Command
         {--no-cache : Re-download archives instead of reusing the cache}
         {--json : Emit machine-readable output}';
 
-    /**
-     * @var string
-     */
     protected $description = 'Show what is unaudited, worst first, or audit one package';
 
     public function handle(): int
@@ -98,7 +92,7 @@ final class AuditCommand extends Command
                 'counts' => $report->counts(),
                 'lock_discrepancies' => $discrepancies,
                 'unaudited' => array_values(array_map(function (PackageAudit $c) use ($project, $auditor): array {
-                    $review = $this->review($project, $auditor, $c);
+                    $delta = $this->review($project, $auditor, $c);
 
                     return [
                         'package' => $c->package,
@@ -106,13 +100,13 @@ final class AuditCommand extends Command
                         'status' => $c->status->value,
                         'dev' => $c->dev,
                         'files' => $c->files,
-                        'files_to_review' => $review['files'],
-                        'scope' => $review['scope'],
+                        'files_to_review' => $delta instanceof Delta ? count($delta->changes()) : $c->files,
+                        'scope' => $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package',
                     ];
                 }, $failing)),
             ]));
 
-            return $this->verdict($failing, $discrepancies);
+            return $this->verdict($failing !== [], $discrepancies !== []);
         }
 
         $this->newLine();
@@ -133,7 +127,7 @@ final class AuditCommand extends Command
             $this->components->info(sprintf('All %d packages are covered.', $report->total()));
             $this->newLine();
 
-            if ($this->verdict($failing, $discrepancies) === self::FAILURE) {
+            if ($this->verdict(false, $discrepancies !== []) === self::FAILURE) {
                 $this->components->error('The installed tree does not match composer.lock.');
 
                 return self::FAILURE;
@@ -145,8 +139,12 @@ final class AuditCommand extends Command
         $this->line(sprintf('  <options=bold>to review</> <fg=gray>(%d, worst first)</>', count($failing)));
         $this->newLine();
 
+        $renderer = $this->output->isVerbose() ? new DeltaRenderer($this->output) : null;
+
         foreach ($failing as $audit) {
-            $review = $this->review($project, $auditor, $audit);
+            $delta = $this->review($project, $auditor, $audit);
+            $files = $delta instanceof Delta ? count($delta->changes()) : $audit->files;
+            $scope = $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package';
 
             $this->components->twoColumnDetail(
                 sprintf(
@@ -156,7 +154,7 @@ final class AuditCommand extends Command
                     $audit->version,
                     $audit->dev ? ' <fg=gray>(dev)</>' : '',
                 ),
-                sprintf('<fg=gray>%d files to review (%s)</>', $review['files'], $review['scope']),
+                sprintf('<fg=gray>%d files to review (%s)</>', $files, $scope),
             );
 
             $this->line(sprintf(
@@ -164,6 +162,10 @@ final class AuditCommand extends Command
                 $audit->reason(),
                 Bytes::human($audit->bytes),
             ));
+
+            if ($renderer instanceof DeltaRenderer && $delta instanceof Delta) {
+                $renderer->report($delta);
+            }
         }
 
         $this->newLine();
@@ -173,22 +175,20 @@ final class AuditCommand extends Command
         );
         $this->newLine();
 
-        $this->components->error(sprintf(
-            '%d package(s) are not covered. Read the delta with `pet audit %s -v`, then record it with `pet trust`.',
-            count($failing),
-            array_key_first($failing),
-        ));
+        $this->components->error($this->output->isVerbose()
+            ? sprintf('%d package(s) are not covered. Record them with `pet trust`.', count($failing))
+            : sprintf(
+                '%d package(s) are not covered. Read the delta with `pet audit %s -v`, then record it with `pet trust`.',
+                count($failing),
+                array_key_first($failing),
+            ));
 
         return self::FAILURE;
     }
 
-    /**
-     * @param  array<string, PackageAudit>  $failing
-     * @param  array<int, string>  $discrepancies
-     */
-    private function verdict(array $failing, array $discrepancies): int
+    private function verdict(bool $hasFailing, bool $hasDiscrepancies): int
     {
-        return $failing === [] && $discrepancies === [] ? self::SUCCESS : self::FAILURE;
+        return ! $hasFailing && ! $hasDiscrepancies ? self::SUCCESS : self::FAILURE;
     }
 
     private function auditPackage(Project $project, string $package): int
@@ -282,27 +282,19 @@ final class AuditCommand extends Command
         return $covered ? self::SUCCESS : self::FAILURE;
     }
 
-    /**
-     * @return array{files: int, scope: string}
-     */
-    private function review(Project $project, Auditor $auditor, PackageAudit $audit): array
+    private function review(Project $project, Auditor $auditor, PackageAudit $audit): ?Delta
     {
         $from = $auditor->ledger->grantFor($audit->package)?->version;
 
         if ($from === null) {
-            return ['files' => $audit->files, 'scope' => 'whole package'];
+            return null;
         }
 
         try {
-            $delta = DeltaResolver::forProject($project)->resolve($audit->package, $from);
+            return DeltaResolver::forProject($project)->resolve($audit->package, $from);
         } catch (PetException) {
-            return ['files' => $audit->files, 'scope' => 'whole package'];
+            return null;
         }
-
-        return [
-            'files' => count($delta->changes()),
-            'scope' => sprintf('delta from %s', $delta->from),
-        ];
     }
 
     private function deltaFrom(?Grant $grant, Package $installed): ?string

--- a/app/Commands/AuditCommand.php
+++ b/app/Commands/AuditCommand.php
@@ -37,7 +37,7 @@ final class AuditCommand extends Command
     public function handle(): int
     {
         try {
-            $project = Project::locate($this->stringOption('path') ?? (string)getcwd());
+            $project = Project::locate($this->stringOption('path') ?? (string) getcwd());
         } catch (PetException $petException) {
             $this->components->error($petException->getMessage());
 
@@ -75,39 +75,39 @@ final class AuditCommand extends Command
 
         $failing = $report->failing();
 
-        uasort($failing, static fn(PackageAudit $a, PackageAudit $b): int => [
-                self::statusWeight($a->status),
-                $b->files,
-                $a->package,
-            ] <=> [
-                self::statusWeight($b->status),
-                $a->files,
-                $b->package,
-            ]);
+        uasort($failing, static fn (PackageAudit $a, PackageAudit $b): int => [
+            self::statusWeight($a->status),
+            $b->files,
+            $a->package,
+        ] <=> [
+            self::statusWeight($b->status),
+            $a->files,
+            $b->package,
+        ]);
 
         if ($this->option(
-                'json'
-            ) === true) {
+            'json'
+        ) === true) {
             $this->output->write(Json::encode([
-                        'total' => $report->total(),
-                        'covered' => $report->coveredCount(),
-                        'percentage' => $report->percentage(),
-                        'counts' => $report->counts(),
-                        'lock_discrepancies' => $discrepancies,
-                        'unaudited' => array_values(array_map(function (PackageAudit $c) use ($project, $auditor): array {
-                                    $delta = $this->review($project, $auditor, $c);
+                'total' => $report->total(),
+                'covered' => $report->coveredCount(),
+                'percentage' => $report->percentage(),
+                'counts' => $report->counts(),
+                'lock_discrepancies' => $discrepancies,
+                'unaudited' => array_values(array_map(function (PackageAudit $c) use ($project, $auditor): array {
+                    $delta = $this->review($project, $auditor, $c);
 
-                                    return [
-                                        'package' => $c->package,
-                                        'version' => $c->version,
-                                        'status' => $c->status->value,
-                                        'dev' => $c->dev,
-                                        'files' => $c->files,
-                                        'files_to_review' => $delta instanceof Delta ? count($delta->changes()) : $c->files,
-                                        'scope' => $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package',
-                                    ];
-                                }, $failing)),
-                    ]));
+                    return [
+                        'package' => $c->package,
+                        'version' => $c->version,
+                        'status' => $c->status->value,
+                        'dev' => $c->dev,
+                        'files' => $c->files,
+                        'files_to_review' => $delta instanceof Delta ? count($delta->changes()) : $c->files,
+                        'scope' => $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package',
+                    ];
+                }, $failing)),
+            ]));
 
             return $this->verdict($failing !== [], $discrepancies !== []);
         }
@@ -179,11 +179,8 @@ final class AuditCommand extends Command
                         $audit->bytes
                     ),
                     $diffUrl === null ? '' : sprintf(
-                        "\n      Diff: %s",
-                        $this->link(
-                            $diffUrl,
-                            $diffUrl
-                        )
+                        "\n      Changed files: %s",
+                        $this->link($diffUrl)
                     ),
                 )
             );
@@ -205,7 +202,8 @@ final class AuditCommand extends Command
         $this->components->error(
             $this->output->isVerbose()
                 ? sprintf('%d package(s) are not covered. Record them with `pet trust`.', count($failing))
-                : sprintf('%d package(s) are not covered. Read the delta with `pet audit %s -v`, then record it with `pet trust`.', count($failing), array_key_first($failing),));
+                : sprintf('%d package(s) are not covered. Read the delta with `pet audit %s -v`, then record it with `pet trust`.', count($failing), array_key_first($failing)));
+
         return self::FAILURE;
     }
 
@@ -289,20 +287,13 @@ final class AuditCommand extends Command
         );
 
         if ($delta instanceof Delta) {
-            $renderer->report($delta, $this->stringOption('bucket'));
+            $diffLink = SourceDiffUrl::between($installed->sourceUrl, $delta->from, $delta->to);
+            $renderer->report($delta, $this->stringOption('bucket'), $diffLink !== null ? $this->link($diffLink) : null);
         } else {
             $this->newLine();
 
             if ($unresolved !== null) {
                 $this->components->warn($unresolved);
-            }
-        }
-
-        if ($delta instanceof Delta) {
-            $diffUrl = SourceDiffUrl::between($installed->sourceUrl, $delta->from, $delta->to);
-
-            if ($diffUrl !== null) {
-                $this->components->twoColumnDetail('diff', $this->link($diffUrl));
             }
         }
 
@@ -342,7 +333,7 @@ final class AuditCommand extends Command
 
     private function relative(string $root, string $path): string
     {
-        return str_starts_with($path, $root . '/') ? mb_substr($path, mb_strlen($root) + 1) : $path;
+        return str_starts_with($path, $root.'/') ? mb_substr($path, mb_strlen($root) + 1) : $path;
     }
 
     private function link(string $url, ?string $label = null): string

--- a/app/Commands/AuditCommand.php
+++ b/app/Commands/AuditCommand.php
@@ -18,6 +18,7 @@ use App\Lock\Project;
 use App\Support\Bytes;
 use App\Support\DeltaRenderer;
 use App\Support\Json;
+use App\Support\SourceDiffUrl;
 use LaravelZero\Framework\Commands\Command;
 
 final class AuditCommand extends Command
@@ -36,7 +37,7 @@ final class AuditCommand extends Command
     public function handle(): int
     {
         try {
-            $project = Project::locate($this->stringOption('path') ?? (string) getcwd());
+            $project = Project::locate($this->stringOption('path') ?? (string)getcwd());
         } catch (PetException $petException) {
             $this->components->error($petException->getMessage());
 
@@ -74,37 +75,39 @@ final class AuditCommand extends Command
 
         $failing = $report->failing();
 
-        uasort($failing, static fn (PackageAudit $a, PackageAudit $b): int => [
-            self::statusWeight($a->status),
-            $b->files,
-            $a->package,
-        ] <=> [
-            self::statusWeight($b->status),
-            $a->files,
-            $b->package,
-        ]);
+        uasort($failing, static fn(PackageAudit $a, PackageAudit $b): int => [
+                self::statusWeight($a->status),
+                $b->files,
+                $a->package,
+            ] <=> [
+                self::statusWeight($b->status),
+                $a->files,
+                $b->package,
+            ]);
 
-        if ($this->option('json') === true) {
+        if ($this->option(
+                'json'
+            ) === true) {
             $this->output->write(Json::encode([
-                'total' => $report->total(),
-                'covered' => $report->coveredCount(),
-                'percentage' => $report->percentage(),
-                'counts' => $report->counts(),
-                'lock_discrepancies' => $discrepancies,
-                'unaudited' => array_values(array_map(function (PackageAudit $c) use ($project, $auditor): array {
-                    $delta = $this->review($project, $auditor, $c);
+                        'total' => $report->total(),
+                        'covered' => $report->coveredCount(),
+                        'percentage' => $report->percentage(),
+                        'counts' => $report->counts(),
+                        'lock_discrepancies' => $discrepancies,
+                        'unaudited' => array_values(array_map(function (PackageAudit $c) use ($project, $auditor): array {
+                                    $delta = $this->review($project, $auditor, $c);
 
-                    return [
-                        'package' => $c->package,
-                        'version' => $c->version,
-                        'status' => $c->status->value,
-                        'dev' => $c->dev,
-                        'files' => $c->files,
-                        'files_to_review' => $delta instanceof Delta ? count($delta->changes()) : $c->files,
-                        'scope' => $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package',
-                    ];
-                }, $failing)),
-            ]));
+                                    return [
+                                        'package' => $c->package,
+                                        'version' => $c->version,
+                                        'status' => $c->status->value,
+                                        'dev' => $c->dev,
+                                        'files' => $c->files,
+                                        'files_to_review' => $delta instanceof Delta ? count($delta->changes()) : $c->files,
+                                        'scope' => $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package',
+                                    ];
+                                }, $failing)),
+                    ]));
 
             return $this->verdict($failing !== [], $discrepancies !== []);
         }
@@ -116,10 +119,12 @@ final class AuditCommand extends Command
         }
 
         if (! $auditor->ledger->exists()) {
-            $this->components->warn(sprintf(
-                'No ledger yet. `pet trust` records every installed package in %s.',
-                $this->relative($project->rootPath, $auditor->ledger->path),
-            ));
+            $this->components->warn(
+                sprintf(
+                    'No ledger yet. `pet trust` records every installed package in %s.',
+
+                    $this->relative($project->rootPath, $auditor->ledger->path),
+                ));
             $this->newLine();
         }
 
@@ -145,6 +150,15 @@ final class AuditCommand extends Command
             $delta = $this->review($project, $auditor, $audit);
             $files = $delta instanceof Delta ? count($delta->changes()) : $audit->files;
             $scope = $delta instanceof Delta ? sprintf('delta from %s', $delta->from) : 'whole package';
+            $diffUrl = $audit->grant instanceof Grant
+                ? SourceDiffUrl::between(
+                    $auditor->installed()->get(
+                        $audit->package
+                    )->sourceUrl,
+                    $audit->grant->version,
+                    $audit->version,
+                )
+                : null;
 
             $this->components->twoColumnDetail(
                 sprintf(
@@ -157,14 +171,27 @@ final class AuditCommand extends Command
                 sprintf('<fg=gray>%d files to review (%s)</>', $files, $scope),
             );
 
-            $this->line(sprintf(
-                '      <fg=gray>%s  ·  %s</>',
-                $audit->reason(),
-                Bytes::human($audit->bytes),
-            ));
+            $this->line(
+                sprintf(
+                    '      <fg=gray>%s  ·  %s%s</>',
+                    $audit->reason(),
+                    Bytes::human(
+                        $audit->bytes
+                    ),
+                    $diffUrl === null ? '' : sprintf(
+                        "\n      Diff: %s",
+                        $this->link(
+                            $diffUrl,
+                            $diffUrl
+                        )
+                    ),
+                )
+            );
 
             if ($renderer instanceof DeltaRenderer && $delta instanceof Delta) {
-                $renderer->report($delta);
+                $renderer->report(
+                    $delta
+                );
             }
         }
 
@@ -175,14 +202,10 @@ final class AuditCommand extends Command
         );
         $this->newLine();
 
-        $this->components->error($this->output->isVerbose()
-            ? sprintf('%d package(s) are not covered. Record them with `pet trust`.', count($failing))
-            : sprintf(
-                '%d package(s) are not covered. Read the delta with `pet audit %s -v`, then record it with `pet trust`.',
-                count($failing),
-                array_key_first($failing),
-            ));
-
+        $this->components->error(
+            $this->output->isVerbose()
+                ? sprintf('%d package(s) are not covered. Record them with `pet trust`.', count($failing))
+                : sprintf('%d package(s) are not covered. Read the delta with `pet audit %s -v`, then record it with `pet trust`.', count($failing), array_key_first($failing),));
         return self::FAILURE;
     }
 
@@ -275,6 +298,14 @@ final class AuditCommand extends Command
             }
         }
 
+        if ($delta instanceof Delta) {
+            $diffUrl = SourceDiffUrl::between($installed->sourceUrl, $delta->from, $delta->to);
+
+            if ($diffUrl !== null) {
+                $this->components->twoColumnDetail('diff', $this->link($diffUrl));
+            }
+        }
+
         if (! $covered) {
             $this->components->info(sprintf('Record these bytes with `pet trust %s`.', $package));
         }
@@ -285,7 +316,6 @@ final class AuditCommand extends Command
     private function review(Project $project, Auditor $auditor, PackageAudit $audit): ?Delta
     {
         $from = $auditor->ledger->grantFor($audit->package)?->version;
-
         if ($from === null) {
             return null;
         }
@@ -312,20 +342,29 @@ final class AuditCommand extends Command
 
     private function relative(string $root, string $path): string
     {
-        return str_starts_with($path, $root.'/') ? mb_substr($path, mb_strlen($root) + 1) : $path;
+        return str_starts_with($path, $root . '/') ? mb_substr($path, mb_strlen($root) + 1) : $path;
+    }
+
+    private function link(string $url, ?string $label = null): string
+    {
+        return sprintf('<href=%s>%s</>', $url, $label ?: $url);
     }
 
     private function stringArgument(string $name): ?string
     {
         $value = $this->argument($name);
 
-        return is_string($value) && $value !== '' ? $value : null;
+        return is_string(
+            $value
+        ) && $value !== '' ? $value : null;
     }
 
     private function stringOption(string $name): ?string
     {
         $value = $this->option($name);
 
-        return is_string($value) && $value !== '' ? $value : null;
+        return is_string(
+            $value
+        ) && $value !== '' ? $value : null;
     }
 }

--- a/app/Support/DeltaRenderer.php
+++ b/app/Support/DeltaRenderer.php
@@ -50,7 +50,7 @@ final readonly class DeltaRenderer
         ];
     }
 
-    public function report(Delta $delta, ?string $only = null): void
+    public function report(Delta $delta, ?string $only = null, ?string $diffUrl = null): void
     {
         $this->output->newLine();
         $this->output->writeln(sprintf(
@@ -66,6 +66,10 @@ final readonly class DeltaRenderer
 
         if ($delta->toIsLocalInstall) {
             $this->components->twoColumnDetail('<fg=gray>compared against</>', '<fg=gray>your installed tree</>');
+        }
+
+        if ($diffUrl !== null) {
+            $this->components->twoColumnDetail('Changed files', $diffUrl);
         }
 
         foreach ($delta->notes as $note) {

--- a/app/Support/SourceDiffUrl.php
+++ b/app/Support/SourceDiffUrl.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class SourceDiffUrl
+{
+    public static function between(?string $sourceUrl, string $from, string $to): ?string
+    {
+        if ($sourceUrl === null || $from === $to) {
+            return null;
+        }
+
+        $parts = parse_url($sourceUrl);
+
+        if (! is_array($parts)) {
+            return null;
+        }
+
+        $scheme = $parts['scheme'] ?? null;
+        $host = $parts['host'] ?? null;
+        $path = $parts['path'] ?? null;
+
+        if (! is_string($scheme) || $scheme !== 'https' || ! is_string($host) || ! is_string($path)) {
+            return null;
+        }
+
+        $host = mb_strtolower($host);
+        $path = mb_trim($path, '/');
+        $path = preg_replace('/\.git$/', '', $path) ?? $path;
+
+        if (preg_match('/^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+$/', $path) !== 1) {
+            return null;
+        }
+
+        $template = match ($host) {
+            'github.com' => mb_substr_count($path, '/') === 1
+                ? 'https://github.com/%s/compare/%s...%s'
+                : null,
+            'gitlab.com' => 'https://gitlab.com/%s/-/compare/%s...%s',
+            default => null,
+        };
+
+        return $template === null
+            ? null
+            : sprintf($template, $path, rawurlencode($from), rawurlencode($to));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
             "rector process --dry-run",
             "pint --test"
         ],
-        "test:dependencies": "pet audit",
+        "test:dependencies": "./pet audit",
         "test:types": "phpstan analyse",
         "test:unit": "pest --parallel",
         "test": [

--- a/pet.json
+++ b/pet.json
@@ -341,7 +341,7 @@
         },
         "pestphp/pest": {
             "version": "v5.1.1",
-            "hash": "tree-v1:a3003bdb5fd2c27beafe9245e063931c"
+            "hash": "tree-v1:f4876bbd0669d6289e9cb6085a182440"
         },
         "pestphp/pest-plugin": {
             "version": "v5.0.0",

--- a/pet.json
+++ b/pet.json
@@ -43,7 +43,7 @@
         },
         "illuminate/cache": {
             "version": "v13.25.0",
-            "hash": "tree-v1:94c839a4421579a132e136e3d9c8749a"
+            "hash": "tree-v1:b0d80465b7c61397acf64d3c1e66b846"
         },
         "illuminate/collections": {
             "version": "v13.25.0",
@@ -59,7 +59,7 @@
         },
         "illuminate/console": {
             "version": "v13.25.0",
-            "hash": "tree-v1:d031a71c3eddd6fa8ef6850609863804"
+            "hash": "tree-v1:6ff2f68809cd884066877f6646b6eac7"
         },
         "illuminate/container": {
             "version": "v13.25.0",
@@ -67,7 +67,7 @@
         },
         "illuminate/contracts": {
             "version": "v13.25.0",
-            "hash": "tree-v1:d4eb2aa52408b3d5f92fbe2c2da35224"
+            "hash": "tree-v1:41859da58a56ce705c9fe2b011e3c912"
         },
         "illuminate/events": {
             "version": "v13.25.0",
@@ -95,31 +95,31 @@
         },
         "illuminate/support": {
             "version": "v13.25.0",
-            "hash": "tree-v1:f82b6eefa47876614b5534914c681c37"
+            "hash": "tree-v1:81d7a8a855c9b07f905f9e6a5c53d9f0"
         },
         "illuminate/testing": {
             "version": "v13.25.0",
-            "hash": "tree-v1:848772d3d88b918021afa65ff1fc7d01"
+            "hash": "tree-v1:c78c7fd9bf7f692f31dfb9e87e1ad164"
         },
         "illuminate/view": {
             "version": "v13.25.0",
-            "hash": "tree-v1:499bf30eb1bf1179eebda4272b38a5e6"
+            "hash": "tree-v1:597b97106574a4a808b6b87c3dacb3fc"
         },
         "jolicode/jolinotif": {
             "version": "v3.3.1",
-            "hash": "tree-v1:3dd5540d5a72e68063482c3b53aba41f"
+            "hash": "tree-v1:97e8c9bba0ee41220d0271109a80e915"
         },
         "jolicode/php-os-helper": {
             "version": "v0.3.0",
-            "hash": "tree-v1:8536e71f3bca8c6a6afe950f1ce88ab5"
+            "hash": "tree-v1:c23f4b0904493bb51c0e659015aacbb6"
         },
         "laravel-zero/foundation": {
             "version": "v13.25.0",
-            "hash": "tree-v1:1d7d7f9d56f66346fc97d6dcdeb29b4b"
+            "hash": "tree-v1:cff925fe58d8f820e197da5e84fdec26"
         },
         "laravel-zero/framework": {
             "version": "v13.0.0",
-            "hash": "tree-v1:d72a2e1da1e6f7d3c588cc10969af741"
+            "hash": "tree-v1:7079a8ada5d5accf5f9ae99e17d5c3f3"
         },
         "laravel/prompts": {
             "version": "v0.3.22",
@@ -139,19 +139,19 @@
         },
         "nesbot/carbon": {
             "version": "3.13.2",
-            "hash": "tree-v1:234c5d4f300a255952cd9c20d906a8d8"
+            "hash": "tree-v1:4b5b0f7bbfd0203b42177f28b82b0f94"
         },
         "nunomaduro/collision": {
             "version": "v8.9.5",
-            "hash": "tree-v1:322ee464f8c7a859296c1f39375d3a3f"
+            "hash": "tree-v1:305a139f4e45e3dbfd9647cd014e079b"
         },
         "nunomaduro/laravel-console-summary": {
             "version": "v1.14.0",
-            "hash": "tree-v1:a11265335115b616d1f4318801ee23f0"
+            "hash": "tree-v1:425bad2d936669c13d2826d592255ba8"
         },
         "nunomaduro/laravel-console-task": {
             "version": "v1.11.0",
-            "hash": "tree-v1:dd6ca272dce091967dc4452820a2b774"
+            "hash": "tree-v1:2b49b9c56cc5e08e1c57f79a950a03d4"
         },
         "nunomaduro/laravel-desktop-notifier": {
             "version": "v3.0.0",
@@ -187,7 +187,7 @@
         },
         "psr/http-message": {
             "version": "2.0",
-            "hash": "tree-v1:a9575ef4779a21eb0d3f04a1e2f0f008"
+            "hash": "tree-v1:612195dc7224952b2dafe169a085db57"
         },
         "psr/log": {
             "version": "3.0.2",
@@ -211,11 +211,11 @@
         },
         "symfony/clock": {
             "version": "v8.1.0",
-            "hash": "tree-v1:7888f31d60c29c4f777204510e9a60a5"
+            "hash": "tree-v1:be0896673f4d0e63e77c97ef8e2f5421"
         },
         "symfony/console": {
             "version": "v8.1.4",
-            "hash": "tree-v1:6278de8094075df5a00680affe1bc1a0"
+            "hash": "tree-v1:146609a0de40cee40ddbcb2474159131"
         },
         "symfony/deprecation-contracts": {
             "version": "v3.7.1",
@@ -223,11 +223,11 @@
         },
         "symfony/error-handler": {
             "version": "v8.1.2",
-            "hash": "tree-v1:9ead09c89f56303b8cdd247aa2561f86"
+            "hash": "tree-v1:689124cf8e25b14b1f9da9d8ef817e2b"
         },
         "symfony/event-dispatcher": {
             "version": "v8.1.2",
-            "hash": "tree-v1:f98bf51d31b6f97cd343212e6f7b8df2"
+            "hash": "tree-v1:aac3b1989bbfe1bcc7bf86079adb4982"
         },
         "symfony/event-dispatcher-contracts": {
             "version": "v3.7.1",
@@ -235,7 +235,7 @@
         },
         "symfony/finder": {
             "version": "v8.1.1",
-            "hash": "tree-v1:0dc6c8b9312a999436f4f736ce9c33d7"
+            "hash": "tree-v1:9c1eff4420e412cc46d9e9e9c0d753ef"
         },
         "symfony/polyfill-ctype": {
             "version": "v1.37.0",
@@ -271,19 +271,19 @@
         },
         "symfony/process": {
             "version": "v8.1.0",
-            "hash": "tree-v1:0ef49d7bf0109e9d07406727aa8227e5"
+            "hash": "tree-v1:301479061cc69f013a997e3b85473dfa"
         },
         "symfony/service-contracts": {
             "version": "v3.7.1",
-            "hash": "tree-v1:7b156b7e7dd1cf17dd7bde352e355d46"
+            "hash": "tree-v1:e7c5333ebebde0d285388d863040ae47"
         },
         "symfony/string": {
             "version": "v8.1.2",
-            "hash": "tree-v1:6c3dbd245e870cd78bdd16b764534dff"
+            "hash": "tree-v1:9787a20667f5b5eaef9c01dff72e0bbc"
         },
         "symfony/translation": {
             "version": "v8.1.4",
-            "hash": "tree-v1:0cd6421dce1427357556e4e4bd0f77d7"
+            "hash": "tree-v1:5e647486c56fd38bdb5d124de4a253c9"
         },
         "symfony/translation-contracts": {
             "version": "v3.7.1",
@@ -291,7 +291,7 @@
         },
         "symfony/var-dumper": {
             "version": "v8.1.2",
-            "hash": "tree-v1:3329f5b339ccbf4ec6762afa4dad3049"
+            "hash": "tree-v1:abfafb453e06b6fadffb3751ca08d399"
         },
         "vlucas/phpdotenv": {
             "version": "v5.6.4",
@@ -325,7 +325,7 @@
         },
         "laravel/pint": {
             "version": "v1.30.5",
-            "hash": "tree-v1:157af76b649beca07fd5edf43dc16476"
+            "hash": "tree-v1:720e532f509f325d64e376f81694eeff"
         },
         "mockery/mockery": {
             "version": "1.6.13",
@@ -337,15 +337,15 @@
         },
         "nikic/php-parser": {
             "version": "v5.8.0",
-            "hash": "tree-v1:90ddc66bf11d350b722c1773acd27c8d"
+            "hash": "tree-v1:2f8d789b881e26a2599f6700155c7786"
         },
         "pestphp/pest": {
             "version": "v5.1.1",
-            "hash": "tree-v1:a25055498846492a1b6c44b1d997d15c"
+            "hash": "tree-v1:a3003bdb5fd2c27beafe9245e063931c"
         },
         "pestphp/pest-plugin": {
             "version": "v5.0.0",
-            "hash": "tree-v1:805cbcd5555dbbff2069126228c42319"
+            "hash": "tree-v1:82c75804af9a2dcd954a14c47d53550c"
         },
         "pestphp/pest-plugin-arch": {
             "version": "v5.0.0",
@@ -353,7 +353,7 @@
         },
         "pestphp/pest-plugin-mutate": {
             "version": "v5.0.2",
-            "hash": "tree-v1:539c2118cd2c7e19e545c3000f1d68b5"
+            "hash": "tree-v1:c8d1382da4cbf22bb88083a4669f64ac"
         },
         "pestphp/pest-plugin-phpstan": {
             "version": "v5.0.2",
@@ -365,11 +365,11 @@
         },
         "pestphp/pest-plugin-rector": {
             "version": "v5.0.3",
-            "hash": "tree-v1:ea5c4f5c7728dbcc3dce4c04299e39df"
+            "hash": "tree-v1:46b892c115fbc67c9ac3754b02e50a22"
         },
         "phar-io/manifest": {
             "version": "2.0.4",
-            "hash": "tree-v1:7b98d0ed9886b77df04a08280884b27c"
+            "hash": "tree-v1:3799bb32051875727d3e7bc064e45ca0"
         },
         "phar-io/version": {
             "version": "3.2.1",
@@ -377,7 +377,7 @@
         },
         "phpdocumentor/reflection-common": {
             "version": "2.2.0",
-            "hash": "tree-v1:4d02e6474b2c5b0a756adbb6d10bc568"
+            "hash": "tree-v1:0f7e4b7363be6030156e52f96dc93075"
         },
         "phpdocumentor/reflection-docblock": {
             "version": "6.0.3",
@@ -385,7 +385,7 @@
         },
         "phpdocumentor/type-resolver": {
             "version": "2.0.0",
-            "hash": "tree-v1:dbbcdc69a18db06efa73b7c12d48bf39"
+            "hash": "tree-v1:1be39e03df9b18d4516751b65847d53e"
         },
         "phpstan/phpdoc-parser": {
             "version": "2.3.3",
@@ -393,7 +393,7 @@
         },
         "phpstan/phpstan": {
             "version": "2.2.8",
-            "hash": "tree-v1:11220d859d5bd2348fd5077163b60446"
+            "hash": "tree-v1:506c30d468024abbfd7bd23faddf6905"
         },
         "phpunit/php-code-coverage": {
             "version": "14.3.1",
@@ -417,11 +417,11 @@
         },
         "phpunit/phpunit": {
             "version": "13.3.0",
-            "hash": "tree-v1:e1215a6f41346beb602b2af331735bbb"
+            "hash": "tree-v1:aa50c5c614104c300298755a84e27e87"
         },
         "rector/rector": {
             "version": "2.6.2",
-            "hash": "tree-v1:17dfc390ae7c7d468b9d5fc3d38f1f2c"
+            "hash": "tree-v1:8f36f4cce754a6bee1c803034f700e3d"
         },
         "sebastian/cli-parser": {
             "version": "5.0.1",
@@ -489,15 +489,15 @@
         },
         "symplify/rule-doc-generator-contracts": {
             "version": "11.2.0",
-            "hash": "tree-v1:143fc89ce64308c660e6f52de2df9242"
+            "hash": "tree-v1:5da0eb7d673d31edd19a0603bff3ba5b"
         },
         "ta-tikoma/phpunit-architecture-test": {
             "version": "0.8.7",
-            "hash": "tree-v1:068328d7bed81666d79d94c08e5b634b"
+            "hash": "tree-v1:3b1eb7593514f5ff9f032eb975aa0866"
         },
         "theseer/tokenizer": {
             "version": "2.0.1",
-            "hash": "tree-v1:41aaedd9e64befbc0fecc9ff7ea3ea81"
+            "hash": "tree-v1:0cf1d1c40a03f916a29f9f67483ab250"
         },
         "webmozart/assert": {
             "version": "2.4.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
 >
     <testsuites>
         <testsuite name="Arch">
             <file>./tests/Arch.php</file>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>./tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>

--- a/tests/Feature/AuditCommandTest.php
+++ b/tests/Feature/AuditCommandTest.php
@@ -54,12 +54,14 @@ test('the verbose project audit renders source diffs for changed packages', func
             ...$manifest,
             'name' => 'acme/library',
             'version' => '1.0.0',
+        'source' => ['url' => 'https://github.com/acme/library.git', 'reference' => 'from'],
             'dist' => ['url' => $fromUrl, 'reference' => 'from'],
         ];
         $toMetadata = [
             ...$manifest,
             'name' => 'acme/library',
             'version' => '2.0.0',
+            'source' => ['url' => 'https://github.com/acme/library.git', 'reference' => 'to'],
             'dist' => ['url' => 'https://example.test/acme/library-2.0.0.zip', 'reference' => 'to'],
         ];
 
@@ -125,8 +127,24 @@ test('the verbose project audit renders source diffs for changed packages', func
         expect($process->getExitCode())->toBe(1)
             ->and($output)->toContain('runtime source (1)')
             ->and($output)->toContain("      -return 'old';")
-            ->and($output)->toContain("      +return 'new';");
-    } finally {
-        $remove($root);
+            ->and($output)->toContain("      +return 'new';")
+            ->and($output)->toContain('      Diff: https://github.com/acme/library/compare/1.0.0...2.0.0');
+
+        $packageProcess = new Process([
+                PHP_BINARY,
+                dirname(__DIR__, 2).'/pet',
+                '--path='.$root,
+                'audit',
+                'acme/library',
+                '--ansi',
+            ], null, ['PET_CACHE_DIR' => $cache]
+        );
+        $packageProcess->run();
+        $packageOutput = $packageProcess->getOutput().$packageProcess->getErrorOutput();
+        expect($packageProcess->getExitCode())->toBe(1)
+            ->and($packageOutput)->toContain("\033]8;;https://github.com/acme/library/compare/1.0.0...2.0.0\033\\https://github.com/acme/library/compare/1.0.0...2.0.0\033]8;;\033\\");
+        } finally {
+            $remove($root);
+        }
     }
-});
+);

--- a/tests/Feature/AuditCommandTest.php
+++ b/tests/Feature/AuditCommandTest.php
@@ -54,7 +54,7 @@ test('the verbose project audit renders source diffs for changed packages', func
             ...$manifest,
             'name' => 'acme/library',
             'version' => '1.0.0',
-        'source' => ['url' => 'https://github.com/acme/library.git', 'reference' => 'from'],
+            'source' => ['url' => 'https://github.com/acme/library.git', 'reference' => 'from'],
             'dist' => ['url' => $fromUrl, 'reference' => 'from'],
         ];
         $toMetadata = [
@@ -128,23 +128,23 @@ test('the verbose project audit renders source diffs for changed packages', func
             ->and($output)->toContain('runtime source (1)')
             ->and($output)->toContain("      -return 'old';")
             ->and($output)->toContain("      +return 'new';")
-            ->and($output)->toContain('      Diff: https://github.com/acme/library/compare/1.0.0...2.0.0');
+            ->and($output)->toContain('      Changed files: https://github.com/acme/library/compare/1.0.0...2.0.0');
 
         $packageProcess = new Process([
-                PHP_BINARY,
-                dirname(__DIR__, 2).'/pet',
-                '--path='.$root,
-                'audit',
-                'acme/library',
-                '--ansi',
-            ], null, ['PET_CACHE_DIR' => $cache]
+            PHP_BINARY,
+            dirname(__DIR__, 2).'/pet',
+            '--path='.$root,
+            'audit',
+            'acme/library',
+            '--ansi',
+        ], null, ['PET_CACHE_DIR' => $cache]
         );
         $packageProcess->run();
         $packageOutput = $packageProcess->getOutput().$packageProcess->getErrorOutput();
         expect($packageProcess->getExitCode())->toBe(1)
             ->and($packageOutput)->toContain("\033]8;;https://github.com/acme/library/compare/1.0.0...2.0.0\033\\https://github.com/acme/library/compare/1.0.0...2.0.0\033]8;;\033\\");
-        } finally {
-            $remove($root);
-        }
+    } finally {
+        $remove($root);
     }
+}
 );

--- a/tests/Feature/AuditCommandTest.php
+++ b/tests/Feature/AuditCommandTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+test('the verbose project audit renders source diffs for changed packages', function (): void {
+    $root = sys_get_temp_dir().'/pet-audit-'.bin2hex(random_bytes(6));
+    $cache = $root.'/cache';
+    $package = $root.'/vendor/acme/library';
+    $fromUrl = 'https://example.test/acme/library-1.0.0.zip';
+
+    $write = static function (string $path, string $contents): void {
+        $directory = dirname($path);
+
+        if (! is_dir($directory) && ! mkdir($directory, 0o777, true) && ! is_dir($directory)) {
+            throw new RuntimeException(sprintf('Could not create %s.', $directory));
+        }
+
+        if (file_put_contents($path, $contents) === false) {
+            throw new RuntimeException(sprintf('Could not write %s.', $path));
+        }
+    };
+
+    $remove = static function (string $directory) use (&$remove): void {
+        if (! is_dir($directory)) {
+            return;
+        }
+
+        foreach (scandir($directory) ?: [] as $name) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+
+            $path = $directory.'/'.$name;
+
+            if (is_dir($path) && ! is_link($path)) {
+                $remove($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    };
+
+    try {
+        $manifest = [
+            'name' => 'acme/library',
+            'autoload' => ['psr-4' => ['Acme\\' => 'src/']],
+        ];
+        $manifestJson = json_encode($manifest, JSON_THROW_ON_ERROR);
+        $fromMetadata = [
+            ...$manifest,
+            'name' => 'acme/library',
+            'version' => '1.0.0',
+            'dist' => ['url' => $fromUrl, 'reference' => 'from'],
+        ];
+        $toMetadata = [
+            ...$manifest,
+            'name' => 'acme/library',
+            'version' => '2.0.0',
+            'dist' => ['url' => 'https://example.test/acme/library-2.0.0.zip', 'reference' => 'to'],
+        ];
+
+        $write($root.'/composer.json', "{}\n");
+        $write($root.'/composer.lock', json_encode([
+            'content-hash' => 'fixture',
+            'packages' => [$toMetadata],
+            'packages-dev' => [],
+        ], JSON_THROW_ON_ERROR)."\n");
+        $write($root.'/pet.json', json_encode([
+            'schema' => 3,
+            'require' => [
+                'acme/library' => [
+                    'version' => '1.0.0',
+                    'hash' => 'tree-v1:00000000000000000000000000000000',
+                ],
+            ],
+            'require-dev' => (object) [],
+        ], JSON_THROW_ON_ERROR)."\n");
+        $write($package.'/composer.json', $manifestJson);
+        $write($package.'/src/Thing.php', "<?php\nreturn 'new';\n");
+        $write($root.'/vendor/composer/installed.json', json_encode([
+            'packages' => [
+                [
+                    ...$toMetadata,
+                    'install-path' => '../acme/library',
+                    'installation-source' => 'dist',
+                ],
+            ],
+            'dev-package-names' => [],
+        ], JSON_THROW_ON_ERROR)."\n");
+        $write($cache.'/metadata/acme-library.json', json_encode([
+            'packages' => ['acme/library' => [$toMetadata, $fromMetadata]],
+        ], JSON_THROW_ON_ERROR)."\n");
+
+        $archivePath = sprintf(
+            '%s/downloads/acme-library-1.0.0-%s.zip',
+            $cache,
+            mb_substr(hash('sha256', $fromUrl.'|from'), 0, 16),
+        );
+        $write($archivePath, '');
+
+        $archive = new ZipArchive;
+
+        if ($archive->open($archivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new RuntimeException('Could not create the package archive.');
+        }
+
+        $archive->addFromString('acme-library-1.0.0/composer.json', $manifestJson);
+        $archive->addFromString('acme-library-1.0.0/src/Thing.php', "<?php\nreturn 'old';\n");
+        $archive->close();
+
+        $process = new Process([
+            PHP_BINARY,
+            dirname(__DIR__, 2).'/pet',
+            '--path='.$root,
+            'audit',
+            '-v',
+        ], null, ['PET_CACHE_DIR' => $cache]);
+        $process->run();
+        $output = $process->getOutput().$process->getErrorOutput();
+
+        expect($process->getExitCode())->toBe(1)
+            ->and($output)->toContain('runtime source (1)')
+            ->and($output)->toContain("      -return 'old';")
+            ->and($output)->toContain("      +return 'new';");
+    } finally {
+        $remove($root);
+    }
+});


### PR DESCRIPTION
**Note:** When I looked at the code that Codex wrote I realised that the classes are in need of some refactoring and cleaning up to be more readable and maintainable. I thought about how to do it but in the end I decided not to do that. I think thats a job for you since a big refactor by me will probably end up with code you will change again anyway. Better for you to set the overall patterns of the package.

Ultimately, Codex has integrated the new features in a way thats in keeping with the existing vibe coded package.

## Features Added

**1. Links to code comparison between trusted and current code**

<img width="1260" height="657" alt="image" src="https://github.com/user-attachments/assets/22733caf-8e11-47e6-9f67-205dbc08cacf" />

**2. Ensure `pet audit -v` outputs a source diff when used without specifying a package.** 

## Tests

The test generated by codex is a bit wild. I'm not sure what approach to take with it. Feedback is appreciated.

Once the commands are refactored into more manageable classes with specific responsibilities then tests will be easier to write.